### PR TITLE
性別周りの設定を実装 +小オプション

### DIFF
--- a/Assets/VRCAvatars3Tools/README.txt
+++ b/Assets/VRCAvatars3Tools/README.txt
@@ -32,7 +32,7 @@ ver1.0
 	* ツールを作成
 
 ----------------------------------------------------
-〇VRCAvatarConverterTo3 (ver 1.0.0.1)
+〇VRCAvatarConverterTo3 (ver 1.1)
 VRCSDK2で作成したアバター(Avatars2.0)をAvatars3.0のアバターに変換できます。
 
 「VRCAvatars3Tools > VRCAvatarConverterTo3」で以下の機能を持つウィンドウが開きます
@@ -48,14 +48,16 @@ VRCSDK2で作成したアバター(Avatars2.0)をAvatars3.0のアバターに変
  * EyeLookのEyelidsはBlink,LookingUp,LookingDownに最適なBlendShapeを決定できないので、
 	EyelidTypeはNoneにしています。使用する場合は変更して下さい。
 	Blendshapesを選択した場合はEyelidsMeshにBodyという名前のSkinnedMeshRendererが選択されるようにしています。
- * まだEmoteやIdleAnimation, CustomSittingAnimsの変換はできていません。
+ * まだIdleAnimation, CustomSittingAnimsの変換はできていません。
 
 ・使用ライブラリ
  * YamlDotNet for Unity
  Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014 Antoine Aubry
 
  ・更新履歴
- ver1.0.1
+ ver1.1
+	* Emoteも変換されるように
+ ver1.0.0.1
 	* VRCSDK3-AVATAR-2020.07.30.09.18_Public.unitypackageに対応
  ver1.0
 	* ツールを作成

--- a/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarConverterTo3.cs
+++ b/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarConverterTo3.cs
@@ -27,6 +27,7 @@ namespace Gatosyocora.VRCAvatars3Tools
 
         private readonly static Dictionary<string, string> animationTypes = new Dictionary<string, string>
         {
+            {"7400002", "Idle"},
             {"7400052", "Fist"},
             {"7400054", "Point"},
             {"7400056", "RockNRoll"},
@@ -265,6 +266,7 @@ namespace Gatosyocora.VRCAvatars3Tools
                     var state = GetAnimatorStateFromStateName(layer.stateMachine, animationInfo.Type);
                     if (state is null) continue;
                     state.motion = animClip;
+                    state.AddStateMachineBehaviour<VRCAnimatorTrackingControl>();
                 }
             }
 

--- a/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarConverterTo3.cs
+++ b/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarConverterTo3.cs
@@ -346,6 +346,8 @@ namespace Gatosyocora.VRCAvatars3Tools
                         value = int.Parse(animationInfo.Type.Replace("Emote", string.Empty))
                     });
                 }
+
+                Selection.activeObject = exParameters;
             }
 
             AssetDatabase.SaveAssets();

--- a/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarConverterTo3.cs
+++ b/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarConverterTo3.cs
@@ -239,10 +239,12 @@ namespace Gatosyocora.VRCAvatars3Tools
             };
 
             // FaceEmotion
-            var originalHandLayerControllerPath = GetAssetPathForSearch("vrc_AvatarV3HandsLayer t:AnimatorController");
+            var searchTarget = "vrc_AvatarV3HandsLayer t:AnimatorController";
+            if (avatar2Info.DefaultAnimationSet == VRCAvatarDescripterDeserializedObject.AnimationSet.Female) searchTarget = "vrc_AvatarV3HandsLayer2 t:AnimatorController";
+            var originalHandLayerControllerPath = GetAssetPathForSearch(searchTarget);
             var fxController = DuplicateAnimationLayerController(
-                                    originalHandLayerControllerPath, 
-                                    Path.GetDirectoryName(avatar2Info.standingOverrideControllerPath), 
+                                    originalHandLayerControllerPath,
+                                    Path.GetDirectoryName(avatar2Info.standingOverrideControllerPath),
                                     avatarPrefab2.name);
 
             avatar.baseAnimationLayers[(int)AnimationLayerType.FX].isDefault = false;
@@ -392,6 +394,10 @@ namespace Gatosyocora.VRCAvatars3Tools
                 // ScaleIPD
                 avatar2Info.ScaleIPD = ((YamlScalarNode)vrcAvatarDescripter["ScaleIPD"]).Value == "1";
 
+                // Default Animation Set
+                avatar2Info.DefaultAnimationSet = (VRCAvatarDescripterDeserializedObject.AnimationSet)Enum.Parse(typeof(VRCAvatarDescripterDeserializedObject.AnimationSet),
+                                                    ((YamlScalarNode)vrcAvatarDescripter["Animations"]).Value);
+
                 // [LipSync]
                 // Mode
                 var lipSyncTypeIndex = int.Parse(((YamlScalarNode)vrcAvatarDescripter["lipSync"]).Value);
@@ -439,7 +445,7 @@ namespace Gatosyocora.VRCAvatars3Tools
                     {
                         Type = animationTypes[originalClipFileID],
                         Path = AssetDatabase.GUIDToAssetPath(overrideClipGuid)
-                    };                                           
+                    };
                 }
 
                 break;
@@ -464,7 +470,7 @@ namespace Gatosyocora.VRCAvatars3Tools
             string path = string.Empty;
             var node = GetNodeFromGUID(components, rendererGuid);
             var skinnedMeshRenderer = (YamlMappingNode)((YamlMappingNode)node).Children["SkinnedMeshRenderer"];
-            
+
             var gameObjectGuid = ((YamlScalarNode)((YamlMappingNode)skinnedMeshRenderer["m_GameObject"]).Children["fileID"]).Value;
             node = GetNodeFromGUID(components, gameObjectGuid);
             var gameObjectNode = (YamlMappingNode)((YamlMappingNode)node).Children["GameObject"];

--- a/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarConverterTo3.cs
+++ b/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarConverterTo3.cs
@@ -9,7 +9,7 @@ using VRC.SDK3.Avatars.Components;
 using VRC.SDK3.Avatars.ScriptableObjects;
 using YamlDotNet.RepresentationModel;
 
-// ver 1.0.0.1
+// ver 1.1
 // Copyright (c) 2020 gatosyocora
 // MIT License. See LICENSE.txt
 

--- a/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarConverterTo3.cs
+++ b/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarConverterTo3.cs
@@ -54,6 +54,13 @@ namespace Gatosyocora.VRCAvatars3Tools
             FX = 4
         }
 
+        private enum SpecialAnimationLayerType
+        {
+            Sitting = 0,
+            TPose = 1,
+            IKPose = 2
+        }
+
         private bool showViewInfo = true;
         private bool showLipSyncInfo = true;
         private bool showEyeLookInfo = true;
@@ -240,9 +247,9 @@ namespace Gatosyocora.VRCAvatars3Tools
             };
 
             // FaceEmotion
-            var searchTarget = "vrc_AvatarV3HandsLayer t:AnimatorController";
-            if (avatar2Info.DefaultAnimationSet == VRCAvatarDescripterDeserializedObject.AnimationSet.Female) searchTarget = "vrc_AvatarV3HandsLayer2 t:AnimatorController";
-            var originalHandLayerControllerPath = GetAssetPathForSearch(searchTarget);
+            var searchTargetHL = "vrc_AvatarV3HandsLayer t:AnimatorController";
+            if (avatar2Info.DefaultAnimationSet == VRCAvatarDescripterDeserializedObject.AnimationSet.Female) searchTargetHL = "vrc_AvatarV3HandsLayer2 t:AnimatorController";
+            var originalHandLayerControllerPath = GetAssetPathForSearch(searchTargetHL);
             var fxController = DuplicateAnimationLayerController(
                                     originalHandLayerControllerPath,
                                     Path.GetDirectoryName(avatar2Info.standingOverrideControllerPath),
@@ -353,6 +360,21 @@ namespace Gatosyocora.VRCAvatars3Tools
 
                 Selection.activeObject = exParameters;
             }
+
+            // Sitting Animation
+            var searchTargetSL = "vrc_AvatarV3SittingLayer t:AnimatorController";
+            if (avatar2Info.DefaultAnimationSet == VRCAvatarDescripterDeserializedObject.AnimationSet.Female) searchTargetSL = "vrc_AvatarV3SittingLayer2 t:AnimatorController";
+            var originalSittingLayerControllerPath = GetAssetPathForSearch(searchTargetSL);
+            var sittingController = DuplicateAnimationLayerController(
+                                    originalSittingLayerControllerPath,
+                                    Path.GetDirectoryName(avatar2Info.standingOverrideControllerPath),
+                                    avatarPrefab2.name);
+
+            avatar.specialAnimationLayers[(int)SpecialAnimationLayerType.Sitting].isDefault = false;
+            avatar.specialAnimationLayers[(int)SpecialAnimationLayerType.Sitting].isEnabled = true;
+            avatar.specialAnimationLayers[(int)SpecialAnimationLayerType.Sitting].animatorController = sittingController;
+            avatar.specialAnimationLayers[(int)SpecialAnimationLayerType.Sitting].mask = null;
+
 
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();

--- a/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarDescripterDeserializedObject.cs
+++ b/Assets/VRCAvatars3Tools/VRCAvatarConverterTo3/Editor/VRCAvatarDescripterDeserializedObject.cs
@@ -16,6 +16,14 @@ namespace Gatosyocora.VRCAvatars3Tools
         public Vector3 ViewPosition { get; set; }
         public bool ScaleIPD { get; set; }
 
+        public enum AnimationSet
+        {
+            Male = 0,
+            Female = 1,
+            None = 2
+        }
+        public AnimationSet DefaultAnimationSet { get; set; }
+
         // LipSync
         public VRC_AvatarDescriptor.LipSyncStyle lipSync { get; set; }
         public string faceMeshRendererPath { get; set; }


### PR DESCRIPTION
* Idleアニメーションがセットされているアバターがそもそも変換できない状態にあったので，ひとまず読み込むようにしました．
* 表情の干渉防止のために VRCAnimatorTrackingControl を追加することが多くなると思われるので，変換時に自動で追加するようにしました．(これは正直オプションでもいい気はします)

* AV2で元々設定されている Animation Set を取得するようにしました．
  * それに基づいてSittingアニメーションを設定するようにしました．
    * `vrc_AvatarV3SittingLayer `は足を開いたアニメーション，`vrc_AvatarV3SittingLayer2 ` は足を組んだアニメーションが指定されています．AV2に準拠すると，Female設定の場合は後者を選択することになります．
  * それに基づいてHandLayerのIdleを設定するようにしました
    * `vrc_AvatarV3HandsLayer ` は手を軽く握り， `vrc_AvatarV3HandsLayer2 ` はより浅く握っているproxyアニメーションが指定されています．(ただわからないレベルなのでなくてもいい気はします)