### PR TITLE
fix VRCAvatarParameterDriver copy

### DIFF
--- a/Assets/VRCAvatars3Tools/Utilitys/Editor/AnimatorControllerUtility.cs
+++ b/Assets/VRCAvatars3Tools/Utilitys/Editor/AnimatorControllerUtility.cs
@@ -442,12 +442,17 @@ namespace Gatosyocora.VRCAvatars3Tools.Utilitys
                 var srcDriver = srcBehaivour as VRCAvatarParameterDriver;
                 parameterDriver.ApplySettings = srcDriver.ApplySettings;
                 parameterDriver.debugString = srcDriver.debugString;
+                parameterDriver.localOnly = srcDriver.localOnly;
                 parameterDriver.parameters = srcDriver.parameters
                                                 .Select(p =>
                                                 new Parameter
                                                 {
                                                     name = p.name,
-                                                    value = p.value
+                                                    value = p.value,
+                                                    valueMin = p.valueMin,
+                                                    valueMax = p.valueMax,
+                                                    chance = p.chance,
+                                                    type = p.type,
                                                 })
                                                 .ToList();
             }


### PR DESCRIPTION
VRCAvatarParameterDriver の Random/Add等の値やisLocalなどが正しくコピーされていなかった問題を修正